### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/com/tkjelectronics/balanduino/BluetoothChatService.java
+++ b/src/com/tkjelectronics/balanduino/BluetoothChatService.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -224,7 +225,7 @@ public class BluetoothChatService {
     }
 
     public void write(String string) {
-        write(string.getBytes());
+        write(string.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -395,7 +396,7 @@ public class BluetoothChatService {
                     if (mmInStream.available() > 0) { // Check if new data is available
                         bytes = mmInStream.read(buffer); // Read from the InputStream
 
-                        String readMessage = new String(buffer, 0, bytes);
+                        String readMessage = new String(buffer, 0, bytes, StandardCharsets.UTF_8);
                         String[] splitMessage = readMessage.split(",");
 
                         if (D) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
